### PR TITLE
Add about and gallery pages with artwork purchase features

### DIFF
--- a/about.html
+++ b/about.html
@@ -1,9 +1,9 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="ko">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Pandorabox Blog</title>
+    <title>나의 소개</title>
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="stylesheet" href="style.css">
     <script>
@@ -31,17 +31,12 @@
             </nav>
         </div>
     </header>
-    <main class="container mx-auto px-4 py-8 space-y-8">
-        <article class="bg-white rounded shadow p-6">
-            <h2 class="text-2xl font-semibold mb-2">First Post</h2>
-            <p class="text-sm text-gray-500">January 1, 2023</p>
-            <p class="mt-4">This is a sample blog post. Replace this text with your own content.</p>
-        </article>
-        <article class="bg-white rounded shadow p-6">
-            <h2 class="text-2xl font-semibold mb-2">Another Post</h2>
-            <p class="text-sm text-gray-500">February 1, 2023</p>
-            <p class="mt-4">More sample content goes here.</p>
-        </article>
+    <main class="container mx-auto px-4 py-8 space-y-4">
+        <section class="bg-white rounded shadow p-6">
+            <h2 class="text-2xl font-semibold mb-4">나의 소개</h2>
+            <p>안녕하세요! 저는 예술가 판도라입니다. 이 페이지에서는 저와 제 작업에 대해 간단히 소개합니다.</p>
+            <p class="mt-2">주로 디지털 아트와 일러스트 작업을 하며, 다양한 색감과 상상력을 표현하는 것을 좋아합니다. 제 작품은 갤러리 페이지에서 만나보실 수 있습니다.</p>
+        </section>
     </main>
     <footer class="text-center text-sm text-gray-600 py-6">
         &copy; 2023 My Blog

--- a/art1.html
+++ b/art1.html
@@ -1,9 +1,9 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="ko">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Pandorabox Blog</title>
+    <title>작품 1</title>
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="stylesheet" href="style.css">
     <script>
@@ -13,6 +13,9 @@
         function logout() {
             localStorage.removeItem('loggedIn');
             window.location.href = 'login.html';
+        }
+        function buy() {
+            alert('구매가 완료되었습니다!');
         }
     </script>
 </head>
@@ -31,17 +34,13 @@
             </nav>
         </div>
     </header>
-    <main class="container mx-auto px-4 py-8 space-y-8">
-        <article class="bg-white rounded shadow p-6">
-            <h2 class="text-2xl font-semibold mb-2">First Post</h2>
-            <p class="text-sm text-gray-500">January 1, 2023</p>
-            <p class="mt-4">This is a sample blog post. Replace this text with your own content.</p>
-        </article>
-        <article class="bg-white rounded shadow p-6">
-            <h2 class="text-2xl font-semibold mb-2">Another Post</h2>
-            <p class="text-sm text-gray-500">February 1, 2023</p>
-            <p class="mt-4">More sample content goes here.</p>
-        </article>
+    <main class="container mx-auto px-4 py-8">
+        <div class="bg-white rounded shadow p-6">
+            <img src="https://source.unsplash.com/featured/600x400?art" alt="작품1" class="mx-auto mb-4">
+            <h2 class="text-2xl font-semibold mb-2">작품 1</h2>
+            <p class="mb-4">작품 1의 상세 설명입니다. 화려한 색감과 독특한 구성이 돋보이는 작품입니다.</p>
+            <button onclick="buy()" class="bg-blue-500 text-white px-4 py-2 rounded">구매하기</button>
+        </div>
     </main>
     <footer class="text-center text-sm text-gray-600 py-6">
         &copy; 2023 My Blog

--- a/art2.html
+++ b/art2.html
@@ -1,9 +1,9 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="ko">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Pandorabox Blog</title>
+    <title>작품 2</title>
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="stylesheet" href="style.css">
     <script>
@@ -13,6 +13,9 @@
         function logout() {
             localStorage.removeItem('loggedIn');
             window.location.href = 'login.html';
+        }
+        function buy() {
+            alert('구매가 완료되었습니다!');
         }
     </script>
 </head>
@@ -31,17 +34,13 @@
             </nav>
         </div>
     </header>
-    <main class="container mx-auto px-4 py-8 space-y-8">
-        <article class="bg-white rounded shadow p-6">
-            <h2 class="text-2xl font-semibold mb-2">First Post</h2>
-            <p class="text-sm text-gray-500">January 1, 2023</p>
-            <p class="mt-4">This is a sample blog post. Replace this text with your own content.</p>
-        </article>
-        <article class="bg-white rounded shadow p-6">
-            <h2 class="text-2xl font-semibold mb-2">Another Post</h2>
-            <p class="text-sm text-gray-500">February 1, 2023</p>
-            <p class="mt-4">More sample content goes here.</p>
-        </article>
+    <main class="container mx-auto px-4 py-8">
+        <div class="bg-white rounded shadow p-6">
+            <img src="https://source.unsplash.com/featured/600x401?painting" alt="작품2" class="mx-auto mb-4">
+            <h2 class="text-2xl font-semibold mb-2">작품 2</h2>
+            <p class="mb-4">작품 2의 상세 설명입니다. 섬세한 터치와 감성적인 분위기가 특징입니다.</p>
+            <button onclick="buy()" class="bg-blue-500 text-white px-4 py-2 rounded">구매하기</button>
+        </div>
     </main>
     <footer class="text-center text-sm text-gray-600 py-6">
         &copy; 2023 My Blog

--- a/art3.html
+++ b/art3.html
@@ -1,9 +1,9 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="ko">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Pandorabox Blog</title>
+    <title>작품 3</title>
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="stylesheet" href="style.css">
     <script>
@@ -13,6 +13,9 @@
         function logout() {
             localStorage.removeItem('loggedIn');
             window.location.href = 'login.html';
+        }
+        function buy() {
+            alert('구매가 완료되었습니다!');
         }
     </script>
 </head>
@@ -31,17 +34,13 @@
             </nav>
         </div>
     </header>
-    <main class="container mx-auto px-4 py-8 space-y-8">
-        <article class="bg-white rounded shadow p-6">
-            <h2 class="text-2xl font-semibold mb-2">First Post</h2>
-            <p class="text-sm text-gray-500">January 1, 2023</p>
-            <p class="mt-4">This is a sample blog post. Replace this text with your own content.</p>
-        </article>
-        <article class="bg-white rounded shadow p-6">
-            <h2 class="text-2xl font-semibold mb-2">Another Post</h2>
-            <p class="text-sm text-gray-500">February 1, 2023</p>
-            <p class="mt-4">More sample content goes here.</p>
-        </article>
+    <main class="container mx-auto px-4 py-8">
+        <div class="bg-white rounded shadow p-6">
+            <img src="https://source.unsplash.com/featured/600x402?illustration" alt="작품3" class="mx-auto mb-4">
+            <h2 class="text-2xl font-semibold mb-2">작품 3</h2>
+            <p class="mb-4">작품 3의 상세 설명입니다. 실험적인 스타일과 창의적인 요소가 돋보입니다.</p>
+            <button onclick="buy()" class="bg-blue-500 text-white px-4 py-2 rounded">구매하기</button>
+        </div>
     </main>
     <footer class="text-center text-sm text-gray-600 py-6">
         &copy; 2023 My Blog

--- a/gallery.html
+++ b/gallery.html
@@ -1,9 +1,9 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="ko">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Pandorabox Blog</title>
+    <title>작품 갤러리</title>
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="stylesheet" href="style.css">
     <script>
@@ -31,17 +31,25 @@
             </nav>
         </div>
     </header>
-    <main class="container mx-auto px-4 py-8 space-y-8">
-        <article class="bg-white rounded shadow p-6">
-            <h2 class="text-2xl font-semibold mb-2">First Post</h2>
-            <p class="text-sm text-gray-500">January 1, 2023</p>
-            <p class="mt-4">This is a sample blog post. Replace this text with your own content.</p>
-        </article>
-        <article class="bg-white rounded shadow p-6">
-            <h2 class="text-2xl font-semibold mb-2">Another Post</h2>
-            <p class="text-sm text-gray-500">February 1, 2023</p>
-            <p class="mt-4">More sample content goes here.</p>
-        </article>
+    <main class="container mx-auto px-4 py-8">
+        <h2 class="text-2xl font-semibold mb-6">작품 갤러리</h2>
+        <div class="grid grid-cols-1 md:grid-cols-3 gap-6">
+            <div class="bg-white rounded shadow p-4 text-center">
+                <img src="https://source.unsplash.com/featured/300x200?art" alt="작품1" class="mx-auto mb-2">
+                <h3 class="font-semibold">작품 1</h3>
+                <a href="art1.html" class="text-blue-500 underline">상세 보기</a>
+            </div>
+            <div class="bg-white rounded shadow p-4 text-center">
+                <img src="https://source.unsplash.com/featured/300x201?painting" alt="작품2" class="mx-auto mb-2">
+                <h3 class="font-semibold">작품 2</h3>
+                <a href="art2.html" class="text-blue-500 underline">상세 보기</a>
+            </div>
+            <div class="bg-white rounded shadow p-4 text-center">
+                <img src="https://source.unsplash.com/featured/300x202?illustration" alt="작품3" class="mx-auto mb-2">
+                <h3 class="font-semibold">작품 3</h3>
+                <a href="art3.html" class="text-blue-500 underline">상세 보기</a>
+            </div>
+        </div>
     </main>
     <footer class="text-center text-sm text-gray-600 py-6">
         &copy; 2023 My Blog


### PR DESCRIPTION
## Summary
- update navigation on home page
- add `about.html`
- add `gallery.html` with example artworks
- add detail pages (`art1.html`, `art2.html`, `art3.html`) with purchase button

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685cb8a2cf148325bd362923891430d9